### PR TITLE
ENT-12158: Removed left/right padding from images and frames

### DIFF
--- a/themes/docs/styles/less/article.less
+++ b/themes/docs/styles/less/article.less
@@ -49,7 +49,7 @@ article {
     }
 
     img, iframe {
-      padding: 32px 16px 40px;
+      padding: 32px 4px 40px; // 4px is for the drop shadow
       box-sizing: border-box;
     }
     


### PR DESCRIPTION
Ticket: ENT-12158

<img width="701" height="919" alt="image" src="https://github.com/user-attachments/assets/edb4d7ca-c973-428f-90ed-1224722cb96e" />
